### PR TITLE
Bump ivcap-ai-tool to >=0.7.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "ivcap-ai-tool (>=0.7.15,<0.8.0)",
+    "ivcap-ai-tool (>=0.7.22,<0.8.0)",
     "pydantic (>=2.11.4,<3.0.0)"
 ]
 


### PR DESCRIPTION
I had to bump this version up to get the Job Events working in https://github.com/science-digital/simple-job-events-demo